### PR TITLE
s2221, ta9032: resolvers added to properties file. caom2-datalinke-se…

### DIFF
--- a/caom2-datalink-server/build.gradle
+++ b/caom2-datalink-server/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.8'
+version = '1.7.1'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'
@@ -29,7 +29,7 @@ dependencies {
     compile 'org.opencadc:cadc-uws-server:1.+'
     compile 'org.opencadc:caom2:[2.3.4,3.0)'
     compile 'org.opencadc:caom2-compute:[2.3,3.0)'
-    compile 'org.opencadc:caom2-tap:[1.7,)'
+    compile 'org.opencadc:caom2-tap:[1.6.1,)'
 
     testCompile 'junit:junit:[4.0,5.0)'
 }

--- a/caom2-datalink-server/build.gradle
+++ b/caom2-datalink-server/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.7'
+version = '1.8'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'
@@ -29,7 +29,7 @@ dependencies {
     compile 'org.opencadc:cadc-uws-server:1.+'
     compile 'org.opencadc:caom2:[2.3.4,3.0)'
     compile 'org.opencadc:caom2-compute:[2.3,3.0)'
-    compile 'org.opencadc:caom2-tap:[1.6,)'
+    compile 'org.opencadc:caom2-tap:[1.7,)'
 
     testCompile 'junit:junit:[4.0,5.0)'
 }

--- a/caom2-tap/build.gradle
+++ b/caom2-tap/build.gradle
@@ -10,7 +10,7 @@ repositories {
     mavenLocal()
 }
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.6.1
 
 group = 'org.opencadc'
 
@@ -27,7 +27,7 @@ dependencies {
     compile 'org.opencadc:cadc-dali:[1.1,)'
     compile 'org.opencadc:cadc-vos:1.+'
     compile 'org.opencadc:caom2:[2.3.4,3.0)'
-    compile 'org.opencadc:caom2-artifact-resolvers:[1.1.0,)'
+    compile 'org.opencadc:caom2-artifact-resolvers:[1.1,)'
  
     testCompile 'junit:junit:[4.0,5.0)'
 }

--- a/caom2-tap/build.gradle
+++ b/caom2-tap/build.gradle
@@ -10,11 +10,11 @@ repositories {
     mavenLocal()
 }
 
-sourceCompatibility = 1.6.1
+sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.7'
+version = '1.6.1'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'

--- a/caom2-tap/build.gradle
+++ b/caom2-tap/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.6'
+version = '1.7'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'

--- a/caom2-tap/build.gradle
+++ b/caom2-tap/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     compile 'org.opencadc:cadc-dali:[1.1,)'
     compile 'org.opencadc:cadc-vos:1.+'
     compile 'org.opencadc:caom2:[2.3.4,3.0)'
-    compile 'org.opencadc:caom2-artifact-resolvers:[1.0,)'
+    compile 'org.opencadc:caom2-artifact-resolvers:[1.1.0,)'
  
     testCompile 'junit:junit:[4.0,5.0)'
 }

--- a/caom2-tap/src/main/resources/CaomArtifactResolver.properties
+++ b/caom2-tap/src/main/resources/CaomArtifactResolver.properties
@@ -3,11 +3,14 @@
 #
 # scheme:<class name of SchemeHandler impl>
 
-
 #ad=ca.nrc.cadc.caom2.artifact.resolvers.AdResolver
 ad=ca.nrc.cadc.caom2ops.AdCutoutGenerator
-
+chandra=ca.nrc.cadc.caom2.artifact.resolvers.ChandraResolver
 gemini=ca.nrc.cadc.caom2.artifact.resolvers.GeminiResolver
+noao=ca.nrc.cadc.caom2.artifact.resolvers.NoaoResolver
+sdss=ca.nrc.cadc.caom2.artifact.resolvers.SdssResolver
+smoka=ca.nrc.cadc.caom2.artifact.resolvers.SmokaResolver
+xmm=ca.nrc.cadc.caom2.artifact.resolvers.XmmResolver
 
 # mast resolver for MAST/STScI URLs
 #mast=ca.nrc.cadc.caom2.artifact.resolvers.MastResolver


### PR DESCRIPTION
…rver build.gradle version upped to match.

This 

caom2-sandbox has a pull request (#5) that needs to be competed as well in order to have sc2links use the newer version of the resolvers.