### PR TITLE
add package service links and clean up RUNID usage

### DIFF
--- a/caom2-datalink-server/build.gradle
+++ b/caom2-datalink-server/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.7.2'
+version = '1.8.0'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'

--- a/caom2-datalink-server/src/main/java/ca/nrc/cadc/caom2/datalink/ArtifactProcessor.java
+++ b/caom2-datalink-server/src/main/java/ca/nrc/cadc/caom2/datalink/ArtifactProcessor.java
@@ -447,7 +447,7 @@ public class ArtifactProcessor
     /**
      * Find the package service associated with a publisherID.
      * 
-     * @param publisherID
+     * @param id
      * @return base package service url for current auth method or null if no such service
      */
     protected URL getBasePackageURL(URI id) {

--- a/caom2-datalink-server/src/main/java/ca/nrc/cadc/caom2/datalink/ArtifactProcessor.java
+++ b/caom2-datalink-server/src/main/java/ca/nrc/cadc/caom2/datalink/ArtifactProcessor.java
@@ -242,7 +242,7 @@ public class ArtifactProcessor
                 }
             }
         }
-        log.warn("numFiles: " + numFiles);
+        log.debug("numFiles: " + numFiles);
         if (numFiles > 1) {
             
             URL pkg = getBasePackageURL(uri);

--- a/caom2-datalink-server/src/main/java/ca/nrc/cadc/caom2/datalink/DataLink.java
+++ b/caom2-datalink-server/src/main/java/ca/nrc/cadc/caom2/datalink/DataLink.java
@@ -99,7 +99,8 @@ public class DataLink implements Iterable<Object>
         DERIVATION("#derivation"),
         PROC("#proc"),
         CUTOUT("#cutout"),
-        THUMBNAIL("http://www.openadc.org/caom2#thumbnail");
+        THUMBNAIL("http://www.openadc.org/caom2#thumbnail"),
+        PKG("http://www.openadc.org/caom2#pkg");
         
         private final String value;
         private Term(String value) { this.value = value; }
@@ -252,6 +253,6 @@ public class DataLink implements Iterable<Object>
     @Override
     public String toString()
     {
-        return "DataLink[" + id + "," + url + "]";
+        return "DataLink[" + id + "," + url + "," + semantics + "]";
     }
 }

--- a/caom2-datalink-server/src/main/java/ca/nrc/cadc/caom2/datalink/DynamicTableData.java
+++ b/caom2-datalink-server/src/main/java/ca/nrc/cadc/caom2/datalink/DynamicTableData.java
@@ -191,7 +191,6 @@ public class DynamicTableData implements TableData
                     }
                     if (pubID != null || planeURI != null)
                     {
-                        
                         try
                         {   
                             ArtifactQueryResult ar;

--- a/caom2-datalink-server/src/main/java/ca/nrc/cadc/caom2/datalink/LinkQueryRunner.java
+++ b/caom2-datalink-server/src/main/java/ca/nrc/cadc/caom2/datalink/LinkQueryRunner.java
@@ -210,7 +210,7 @@ public class LinkQueryRunner implements JobRunner
                 runID = job.getRunID();
             
             CaomTapQuery query = new CaomTapQuery(tapServiceID, runID);
-            ArtifactProcessor ap = new ArtifactProcessor(dlc.getSodaID(), runID);
+            ArtifactProcessor ap = new ArtifactProcessor(dlc, runID);
             ap.setDownloadOnly(downloadFilesOnly); 
             DynamicTableData dtd = null;
             if (downloadFilesOnly)

--- a/caom2-datalink-server/src/test/java/ca/nrc/cadc/caom2/datalink/ArtifactProcessorTest.java
+++ b/caom2-datalink-server/src/test/java/ca/nrc/cadc/caom2/datalink/ArtifactProcessorTest.java
@@ -93,7 +93,7 @@ public class ArtifactProcessorTest
 
     static
     {
-        Log4jInit.setLevel("ca.nrc.cadc.caom2.datalink", Level.INFO);
+        Log4jInit.setLevel("ca.nrc.cadc.caom2", Level.DEBUG);
     }
 
     static String PLANE_URI = "ivo://cadc.nrc.ca/IRIS?bar/baz";

--- a/caom2-datalink-server/src/test/java/ca/nrc/cadc/caom2/datalink/ArtifactProcessorTest.java
+++ b/caom2-datalink-server/src/test/java/ca/nrc/cadc/caom2/datalink/ArtifactProcessorTest.java
@@ -93,7 +93,7 @@ public class ArtifactProcessorTest
 
     static
     {
-        Log4jInit.setLevel("ca.nrc.cadc.caom2", Level.DEBUG);
+        Log4jInit.setLevel("ca.nrc.cadc.caom2", Level.INFO);
     }
 
     static String PLANE_URI = "ivo://cadc.nrc.ca/IRIS?bar/baz";

--- a/caom2-datalink-server/src/test/resources/ServiceConfig.properties
+++ b/caom2-datalink-server/src/test/resources/ServiceConfig.properties
@@ -1,0 +1,8 @@
+ca.nrc.cadc.caom2ops.ServiceConfig.tapServiceID = ivo://cadc.nrc.ca/tap
+
+ca.nrc.cadc.caom2ops.ServiceConfig.metaServiceID = ivo://cadc.nrc.ca/caom2ops
+
+ca.nrc.cadc.caom2ops.ServiceConfig.pkgServiceID = ivo://cadc.nrc.ca/caom2ops
+
+ca.nrc.cadc.caom2ops.ServiceConfig.sodaServiceID = ivo://cadc.nrc.ca/caom2ops
+

--- a/caom2-pkg-server/build.gradle
+++ b/caom2-pkg-server/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.6'
+version = '1.6.1'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'

--- a/caom2-pkg-server/src/main/java/ca/nrc/cadc/caom2/pkg/PackageRunner.java
+++ b/caom2-pkg-server/src/main/java/ca/nrc/cadc/caom2/pkg/PackageRunner.java
@@ -204,6 +204,7 @@ public class PackageRunner implements JobRunner
             
             CaomArtifactResolver artifactResolver = new CaomArtifactResolver();
             artifactResolver.setAuthMethod(proxyAuthMethod); // override auth method for proxied calls
+            artifactResolver.setRunID(runID);
             
             for (String suri : idList)
             {

--- a/caom2-soda-server/build.gradle
+++ b/caom2-soda-server/build.gradle
@@ -14,7 +14,7 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.5.1'
+version = '1.5.2'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'

--- a/caom2-soda-server/src/main/java/ca/nrc/cadc/caom2/soda/SodaJobRunner.java
+++ b/caom2-soda-server/src/main/java/ca/nrc/cadc/caom2/soda/SodaJobRunner.java
@@ -289,9 +289,10 @@ public class SodaJobRunner implements JobRunner
             String runID = job.getRunID();
             if (runID == null)
                 runID = job.getID();
-
+            
             CaomTapQuery query = new CaomTapQuery(tapURI, runID);
             CaomArtifactResolver artifactResolver = new CaomArtifactResolver();
+            artifactResolver.setRunID(runID);
             List<Result> jobResults = new ArrayList<>();
             int serialNum = 1;
             for (URI id : ids)
@@ -330,25 +331,8 @@ public class SodaJobRunner implements JobRunner
                                     {
 
                                         URL url = artifactResolver.getURL(a.getURI(), cutout);
-                                        int num = 0;
-                                        if (url.getQuery() != null)
-                                            num = 1;
-                                        StringBuilder sb = new StringBuilder(url.toExternalForm());
-
-                                        if (runID != null)
-                                        {
-                                            if (num == 0)
-                                                sb.append("?");
-                                            else
-                                                sb.append("&");
-                                            sb.append("runid=").append(runID);
-                                            num++;
-                                        }
-
-                                        String ret = sb.toString();
-                                        log.debug("cutout URL: " + ret);
-                                        URI loc = new URI(ret);
-                                        jobResults.add(new Result(RESULT_OK+"-"+serialNum++, loc));
+                                        log.debug("cutout URL: " + url.toExternalForm());
+                                        jobResults.add(new Result(RESULT_OK+"-"+serialNum++, url.toURI()));
                                     }
                                     else
                                     {

--- a/caom2-tap/build.gradle
+++ b/caom2-tap/build.gradle
@@ -14,20 +14,20 @@ sourceCompatibility = 1.7
 
 group = 'org.opencadc'
 
-version = '1.6.4'
+version = '1.6.5'
 
 dependencies {
     compile 'log4j:log4j:1.2.+'
 
-    compile 'org.opencadc:cadc-util:1.+'
-    compile 'org.opencadc:cadc-log:1.+'
+    compile 'org.opencadc:cadc-util:[1.1.1,)'
+    compile 'org.opencadc:cadc-log:[1.0,)'
     compile 'org.opencadc:cadc-cdp:[1.0.1,2.0)'
     compile 'org.opencadc:cadc-registry:[1.3.2,)'
     compile 'org.opencadc:cadc-vosi:[1.0.1,2.0)'
     compile 'org.opencadc:cadc-dali:[1.1,)'
-    compile 'org.opencadc:cadc-vos:1.+'
+    compile 'org.opencadc:cadc-vos:[1.0,)'
     compile 'org.opencadc:caom2:[2.3.4,3.0)'
-    compile 'org.opencadc:caom2-artifact-resolvers:[1.1.3,)'
+    compile 'org.opencadc:caom2-artifact-resolvers:[1.1.4,)'
  
     testCompile 'junit:junit:[4.0,5.0)'
 }


### PR DESCRIPTION
add package service links when datalink finds multiple non-preview downloads
use Traceable tagging interface to determine when to append RUNID to generated download URLs