### PR TITLE
Cadc 9965 Update Gemini cutout generator to support Storage Inventory

### DIFF
--- a/caom2-tap/build.gradle
+++ b/caom2-tap/build.gradle
@@ -16,7 +16,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.7.9'
+version = '1.7.10'
 
 description = 'OpenCADC CAOM2 TAP client library'
 def git_url = 'https://github.com/opencadc/caom2service'
@@ -31,7 +31,7 @@ dependencies {
     compile 'org.opencadc:cadc-tap:[1.0,)'
     compile 'org.opencadc:cadc-dali:[1.1,)'
     compile 'org.opencadc:caom2:[2.4.3,2.5)'
-    compile 'org.opencadc:caom2-artifact-resolvers:[1.2.4,)'
+    compile 'org.opencadc:caom2-artifact-resolvers:[1.2.5,)'
  
     testCompile 'junit:junit:[4.0,5.0)'
 }

--- a/caom2-tap/src/main/java/ca/nrc/cadc/caom2ops/CadcCutoutGenerator.java
+++ b/caom2-tap/src/main/java/ca/nrc/cadc/caom2ops/CadcCutoutGenerator.java
@@ -109,14 +109,6 @@ public class CadcCutoutGenerator extends CadcResolver implements CutoutGenerator
             return base;
         }
 
-        if (label != null) {
-            try {
-                CaomValidator.assertValidPathComponent(AdCutoutGenerator.class, "filename", label);
-            } catch (IllegalArgumentException ex) {
-                throw new UsageFault(ex.getMessage());
-            }
-        }
-
         StringBuilder sb = new StringBuilder();
         sb.append(base.toExternalForm());
         appendCutoutQueryString(sb, cutouts, label, CUTOUT_PARAM);
@@ -135,6 +127,14 @@ public class CadcCutoutGenerator extends CadcResolver implements CutoutGenerator
     // package access so other CutoutGenerator implementations can use it
     static void appendCutoutQueryString(StringBuilder sb, List<String> cutouts, String label, String cutoutParamName) {
         if (cutouts != null && !cutouts.isEmpty()) {
+            if (label != null) {
+                try {
+                    CaomValidator.assertValidPathComponent(AdCutoutGenerator.class, "filename", label);
+                } catch (IllegalArgumentException ex) {
+                    throw new UsageFault(ex.getMessage());
+                }
+            }
+
             boolean add = (sb.indexOf("?") > 0); // already has query params
             if (!add) {
                 sb.append("?");

--- a/caom2-tap/src/main/java/ca/nrc/cadc/caom2ops/CadcGeminiCutoutGenerator.java
+++ b/caom2-tap/src/main/java/ca/nrc/cadc/caom2ops/CadcGeminiCutoutGenerator.java
@@ -3,7 +3,7 @@
 *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
 **************  CENTRE CANADIEN DE DONNÉES ASTRONOMIQUES  **************
 *
-*  (c) 2017.                            (c) 2017.
+*  (c) 2021.                            (c) 2021.
 *  Government of Canada                 Gouvernement du Canada
 *  National Research Council            Conseil national de recherches
 *  Ottawa, Canada, K1A 0R6              Ottawa, Canada, K1A 0R6
@@ -100,8 +100,8 @@ public class CadcGeminiCutoutGenerator extends CadcGeminiResolver implements Cut
         
         StringBuilder sb = new StringBuilder();
         sb.append(base.toExternalForm());
-        String filename = AdCutoutGenerator.generateFilename(uri, label, cutouts);
-        AdCutoutGenerator.appendCutoutQueryString(sb, cutouts, filename);
+        String filename = CadcCutoutGenerator.generateFilename(uri, label, cutouts);
+        CadcCutoutGenerator.appendCutoutQueryString(sb, cutouts, filename);
         
         try {
             return new URL(sb.toString());

--- a/caom2-tap/src/main/java/ca/nrc/cadc/caom2ops/CadcGeminiCutoutGenerator.java
+++ b/caom2-tap/src/main/java/ca/nrc/cadc/caom2ops/CadcGeminiCutoutGenerator.java
@@ -100,8 +100,7 @@ public class CadcGeminiCutoutGenerator extends CadcGeminiResolver implements Cut
         
         StringBuilder sb = new StringBuilder();
         sb.append(base.toExternalForm());
-        String filename = CadcCutoutGenerator.generateFilename(uri, label, cutouts);
-        CadcCutoutGenerator.appendCutoutQueryString(sb, cutouts, filename);
+        CadcCutoutGenerator.appendCutoutQueryString(sb, cutouts, label);
         
         try {
             return new URL(sb.toString());

--- a/caom2-tap/src/main/java/ca/nrc/cadc/caom2ops/CadcMastCutoutGenerator.java
+++ b/caom2-tap/src/main/java/ca/nrc/cadc/caom2ops/CadcMastCutoutGenerator.java
@@ -69,10 +69,7 @@ package ca.nrc.cadc.caom2ops;
 
 import ca.nrc.cadc.caom2.Artifact;
 import ca.nrc.cadc.caom2.artifact.resolvers.CadcMastResolver;
-import ca.nrc.cadc.caom2.artifact.resolvers.CadcResolver;
-import ca.nrc.cadc.net.StorageResolver;
 
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.util.List;

--- a/caom2-tap/src/test/java/ca/nrc/cadc/caom2ops/CadcCutoutGeneratorTest.java
+++ b/caom2-tap/src/test/java/ca/nrc/cadc/caom2ops/CadcCutoutGeneratorTest.java
@@ -95,14 +95,12 @@ public class CadcCutoutGeneratorTest {
         Log4jInit.setLevel("ca.nrc.cadc", Level.INFO);
     }
 
-    private static final String SI_URL = "https://unittest.com/minoc/files";
-
     private static final String CUTOUT1 = "[1][100:200, 100:200]";
     private static final String CUTOUT2 = "[2][300:400, 300:400]";
     private static final String CUTOUT3 = "[3][500:600, 500:600]";
     private static final String CUTOUT4 = "[4][700:800, 700:800]";
 
-    private static final String CADC_FILE_URI = "cadc:Archive/bar.fits.gz";
+    private static final String CADC_FILE_URI = "cadc:Archive/bar.fits";
     private static final String AD_FILE_URI = "ad:Archive/bar.fits.gz"; // invalid uri
 
     CadcCutoutGenerator cutoutGenerator;
@@ -164,6 +162,27 @@ public class CadcCutoutGeneratorTest {
                 Assert.assertEquals("SUB param", "SUB", kv[0]);
                 Assert.assertEquals("pixel cutout value", cutouts.get(i), kv[1]);
             }
+        } catch (Exception unexpected) {
+            log.error("unexpected exception", unexpected);
+            Assert.fail("unexpected exception: " + unexpected);
+        }
+    }
+
+    @Test
+    public void testToURLWithInvalidLabel() {
+        try {
+            String label = "label1%";
+            List<String> cutouts = new ArrayList<String>();
+            cutouts.add(CUTOUT1);
+            cutouts.add(CUTOUT2);
+            cutouts.add(CUTOUT3);
+            cutouts.add(CUTOUT4);
+            URI uri = new URI(CADC_FILE_URI);
+            cutoutGenerator.setAuthMethod(AuthMethod.ANON);
+            cutoutGenerator.toURL(uri, cutouts, label);
+            Assert.fail("should have thrown a UsageFault due to an invalid label");
+        } catch (UsageFault uf) {
+            // expected, success
         } catch (Exception unexpected) {
             log.error("unexpected exception", unexpected);
             Assert.fail("unexpected exception: " + unexpected);


### PR DESCRIPTION
CadcCutoutGenerator was updated not to generate filename and not to forward the label to Storage Inventory. For now, it is assumed that Storage Inventory will generate the needed filename. Much of the code to forward the label to Storage Inventory is in place.