### PR TITLE
CADC-10943: remove getPackageName() from PackageRunner implementation.

### DIFF
--- a/caom2-pkg-server/build.gradle
+++ b/caom2-pkg-server/build.gradle
@@ -13,7 +13,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.8.0'
+version = '1.8.1'
 
 description = 'OpenCADC CAOM2 package server library'
 def git_url = 'https://github.com/opencadc/caom2service'
@@ -30,7 +30,7 @@ dependencies {
     compile 'org.opencadc:cadc-uws-server:[1.2,1.3)'
     compile 'org.opencadc:caom2:[2.4,2.5)'
     compile 'org.opencadc:caom2-tap:[1.7,)'
-    compile 'org.opencadc:cadc-pkg-server:[1.0.0,)'
+    compile 'org.opencadc:cadc-pkg-server:[1.1.1,)'
 
     testCompile 'junit:junit:[4.0,5.0)'
 }

--- a/caom2-pkg-server/src/main/java/ca/nrc/cadc/caom2/pkg/CaomPackageRunner.java
+++ b/caom2-pkg-server/src/main/java/ca/nrc/cadc/caom2/pkg/CaomPackageRunner.java
@@ -161,12 +161,6 @@ public class CaomPackageRunner extends PackageRunner {
     }
 
     @Override
-    protected String getPackageName() {
-        return this.packageName;
-    }
-
-
-    @Override
      public Iterator<PackageItem> getItems() throws IOException {
 
 


### PR DESCRIPTION
Unused function removed from PackageRunner signature in cadc-pkg-server 1.1.1. 