### PR TITLE
Set linkAuthorized flag for pkg entries.

### DIFF
--- a/caom2-datalink-server/build.gradle
+++ b/caom2-datalink-server/build.gradle
@@ -13,7 +13,7 @@ sourceCompatibility = 1.8
 
 group = 'org.opencadc'
 
-version = '1.9.8'
+version = '1.9.9'
 
 description = 'OpenCADC CAOM2 DataLink server library'
 def git_url = 'https://github.com/opencadc/caom2service'

--- a/caom2-datalink-server/src/main/java/ca/nrc/cadc/caom2/datalink/ArtifactProcessor.java
+++ b/caom2-datalink-server/src/main/java/ca/nrc/cadc/caom2/datalink/ArtifactProcessor.java
@@ -241,6 +241,8 @@ public class ArtifactProcessor {
                 try {
                     link.accessURL = getPackageURL(pkg, ar.getPublisherID());
                     link.contentType = PKG_CONTENT_TYPE_TAR;
+                    link.linkAuth = DataLink.LinkAuthTerm.OPTIONAL; // TODO: make configurable
+                    link.linkAuthorized = pkgReadable;
                     link.description = "single download containing all files (previews and thumbnails excluded)";
                 } catch (MalformedURLException ex) {
                     link.errorMessage = "failed to create package link: " + ex;


### PR DESCRIPTION
The `#package` entries have empty `linkAuthorized` entries, which breaks Advanced Search.